### PR TITLE
ci: upgrade to sf cli and other improvements

### DIFF
--- a/.github/workflows/code-analyze.yml
+++ b/.github/workflows/code-analyze.yml
@@ -1,4 +1,3 @@
-# Based on https://github.com/mehdisfdc/sfdx-GitHub-actions/blob/main/.github/workflows/main.yml
 name: Salesforce Code Quality
 
 on:
@@ -9,65 +8,51 @@ jobs:
   PMD:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
-      - name: Setup SFDX
+      - name: Setup Salesforce CLI
         run: |
-          npm install --global sfdx-cli
-          sfdx --version
-          sfdx plugins:install @salesforce/sfdx-scanner
+          npm install --global @salesforce/cli
+          sf plugins:install @salesforce/sfdx-scanner
       - name: SF Code Analyzer - PMD
         run: |
-          sfdx scanner:run --engine pmd --target force-app --pmdconfig=pmd/ruleset.xml --format table --severity-threshold 3
-      
+          sf scanner:run --engine pmd --target force-app --pmdconfig=pmd/ruleset.xml --format table --severity-threshold 3
+
   RetireJS:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
-      - name: Setup SFDX
+      - name: Setup Salesforce CLI
         run: |
-          npm install --global sfdx-cli
-          sfdx --version
-          sfdx plugins:install @salesforce/sfdx-scanner 
+          npm install --global @salesforce/cli
+          sf plugins:install @salesforce/sfdx-scanner 
       - name: SF Code Analyzer - RetireJS
         run: |
-          sfdx scanner:run --engine "retire-js" --target force-app --format table --severity-threshold 3 
-      
+          sf scanner:run --engine "retire-js" --target force-app --format table --severity-threshold 3 
+
   GraphEngine:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
-      - name: Setup SFDX
+      - name: Setup Salesforce CLI
         run: |
-          npm install --global sfdx-cli
-          sfdx --version
-          sfdx plugins:install @salesforce/sfdx-scanner 
+          npm install --global @salesforce/cli
+          sf plugins:install @salesforce/sfdx-scanner 
       - name: SF Code Analyzer - Data Flow Analysis
         run: |
-          sfdx scanner:run:dfa --target force-app --projectdir force-app --format table --severity-threshold 3
+          sf scanner:run:dfa --target force-app --projectdir force-app --format table --severity-threshold 3
 
   ESLint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
-      - name: Setup SFDX
+      - name: Setup Salesforce CLI
         run: |
-          npm install --global sfdx-cli
-          sfdx --version
-          sfdx plugins:install @salesforce/sfdx-scanner
+          npm install --global @salesforce/cli
+          sf plugins:install @salesforce/sfdx-scanner
       - name: SF Code Analyzer - ESLint
         run: |
-          sfdx scanner:run --engine eslint --eslintconfig=.eslintrc.json --target "force-app/**/*.js" --format table --severity-threshold 3
-        
-      
+          sf scanner:run --engine eslint --eslintconfig=.eslintrc.json --target "force-app/**/*.js" --format table --severity-threshold 3

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Create the following three GitHub Workflows and PMD Ruleset:
 `.github/workflows/code-analyze.yml`
 
 ```yaml
-# Based on https://github.com/mehdisfdc/sfdx-GitHub-actions/blob/main/.github/workflows/main.yml
 name: Salesforce Code Quality
 
 on:
@@ -32,66 +31,54 @@ jobs:
   PMD:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
-      - name: Setup SFDX
+      - name: Setup Salesforce CLI
         run: |
-          npm install --global sfdx-cli
-          sfdx --version
-          sfdx plugins:install @salesforce/sfdx-scanner
+          npm install --global @salesforce/cli
+          sf plugins:install @salesforce/sfdx-scanner
       - name: SF Code Analyzer - PMD
         run: |
-          sfdx scanner:run --engine pmd --target force-app --pmdconfig=pmd/ruleset.xml --format table --severity-threshold 3
-      
+          sf scanner:run --engine pmd --target force-app --pmdconfig=pmd/ruleset.xml --format table --severity-threshold 3
+
   RetireJS:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
-      - name: Setup SFDX
+      - name: Setup Salesforce CLI
         run: |
-          npm install --global sfdx-cli
-          sfdx --version
-          sfdx plugins:install @salesforce/sfdx-scanner 
+          npm install --global @salesforce/cli
+          sf plugins:install @salesforce/sfdx-scanner 
       - name: SF Code Analyzer - RetireJS
         run: |
-          sfdx scanner:run --engine "retire-js" --target force-app --format table --severity-threshold 3 
-      
+          sf scanner:run --engine "retire-js" --target force-app --format table --severity-threshold 3 
+
   GraphEngine:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
-      - name: Setup SFDX
+      - name: Setup Salesforce CLI
         run: |
-          npm install --global sfdx-cli
-          sfdx --version
-          sfdx plugins:install @salesforce/sfdx-scanner 
+          npm install --global @salesforce/cli
+          sf plugins:install @salesforce/sfdx-scanner 
       - name: SF Code Analyzer - Data Flow Analysis
         run: |
-          sfdx scanner:run:dfa --target force-app --projectdir force-app --format table --severity-threshold 3
+          sf scanner:run:dfa --target force-app --projectdir force-app --format table --severity-threshold 3
 
   ESLint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
-      - name: Setup SFDX
+      - name: Setup Salesforce CLI
         run: |
-          npm install --global sfdx-cli
-          sfdx --version
-          sfdx plugins:install @salesforce/sfdx-scanner
+          npm install --global @salesforce/cli
+          sf plugins:install @salesforce/sfdx-scanner
       - name: SF Code Analyzer - ESLint
         run: |
-          sfdx scanner:run --engine eslint --eslintconfig=.eslintrc.json --target "force-app/**/*.js" --format table --severity-threshold 3
+          sf scanner:run --engine eslint --eslintconfig=.eslintrc.json --target "force-app/**/*.js" --format table --severity-threshold 3
 ```
 **Note 1**: Each tool scan (engine) runs in an independent job, therefore you may exclude any of those if desired.
 

--- a/hutte.yml
+++ b/hutte.yml
@@ -5,11 +5,4 @@ version: 1.0
 push_script: |
   sf --version
   export SF_LOG_LEVEL=fatal
-  sf project deploy start --ignore-conflicts 1>/dev/null
-
-# Shell script to run when pulling the source code from the scratch org.
-# Adding the "| hutte_track_changes" to the end of the pull command is important in order for
-# hutte to track which metadata was changed.
-pull_script: |
-  export SF_LOG_LEVEL=fatal
-  sf project retrieve start --json --ignore-conflicts | hutte_track_changes
+  sf project deploy start --wait 60 --ignore-conflicts 1>/dev/null

--- a/hutte.yml
+++ b/hutte.yml
@@ -3,11 +3,13 @@ version: 1.0
 # Shell script to run when pushing the source code to the scratch orgs.
 # It's a great place to automate tasks like permission set assignments or data loading.
 push_script: |
-  sfdx --version
-  sfdx force:source:push -f --loglevel fatal 1>/dev/null
+  sf --version
+  export SF_LOG_LEVEL=fatal
+  sf project deploy start --ignore-conflicts 1>/dev/null
 
 # Shell script to run when pulling the source code from the scratch org.
 # Adding the "| hutte_track_changes" to the end of the pull command is important in order for
 # hutte to track which metadata was changed.
 pull_script: |
-  sfdx force:source:pull --loglevel fatal --json -f | hutte_track_changes
+  export SF_LOG_LEVEL=fatal
+  sf project retrieve start --json --ignore-conflicts | hutte_track_changes

--- a/hutte.yml
+++ b/hutte.yml
@@ -4,5 +4,4 @@ version: 1.0
 # It's a great place to automate tasks like permission set assignments or data loading.
 push_script: |
   sf --version
-  export SF_LOG_LEVEL=fatal
-  sf project deploy start --wait 60 --ignore-conflicts 1>/dev/null
+  sf project deploy start --wait 60 --ignore-conflicts


### PR DESCRIPTION
Upgrade to `sf` cli, and other improvements:
- Changed from `sfdx-cli` to `@salesforce/cli` as `sfdx-cli` is deprecated and this replacement is recommended (https://www.npmjs.com/package/sfdx-cli)
- Remove `fetch: 0` for efficiency, as this action does not require to fetch all git branches.
- Other style and minor fixes